### PR TITLE
Fix(widget): Address Bandsintown widget loading and improve diagnostics.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Music from './sections/Music/Music';
 import Tour from './sections/Tour/Tour';
 import SocialFeed from './sections/SocialFeed/SocialFeed';
 import Video from './sections/Video/Video';
+import Releases from './sections/Releases/Releases'; // Import Releases
 import PressKit from './sections/PressKit/PressKit';
 import Contact from './sections/Contact/Contact'; // Import Contact
 
@@ -16,6 +17,7 @@ function App() {
       <Tour />
       <SocialFeed />
       <Video />
+      <Releases /> {/* Add Releases component */}
       <PressKit /> {/* Add PressKit section here */}
       <Contact /> {/* Add Contact component */}
     </div>

--- a/src/sections/Contact/Contact.jsx
+++ b/src/sections/Contact/Contact.jsx
@@ -6,7 +6,7 @@ const Contact = () => {
 
   return (
     <section className={styles.contactSection}>
-      <h2 className={styles.sectionTitle}>Get In Touch / Press</h2>
+      <h2 className={styles.sectionTitle}>Contact & Downloads</h2>
       <div className={styles.contactInfo}>
         <p className={styles.emailLinkWrapper}>
           BOOKING/PRESS: <a href="mailto:alarmalarmmalaga@gmail.com" className={styles.emailLink}>alarmalarmmalaga@gmail.com</a>
@@ -14,7 +14,14 @@ const Contact = () => {
       </div>
       <div className={styles.pressKit}>
         <a href={pressKitUrl} download="AlarmAlarm-PressKit.zip" className={styles.pressKitButton}>
-          DOWNLOAD PRESS KIT
+          DOWNLOAD FULL PRESS KIT
+        </a>
+        {/* New buttons added below */}
+        <a href="/press-kit/photo1.jpg" download="AlarmAlarm_Photo1.jpg" className={styles.pressKitButton}>
+          Photo (High Res)
+        </a>
+        <a href="/public/press-kit/band_logo.png" download="AlarmAlarm_Logo.png" className={styles.pressKitButton}>
+          Band Logo (High Res)
         </a>
       </div>
     </section>

--- a/src/sections/Contact/Contact.module.css
+++ b/src/sections/Contact/Contact.module.css
@@ -34,6 +34,16 @@
   text-decoration: underline; /* Basic hover for now */
 }
 
+/* Container for all press kit download buttons */
+.pressKit {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap; /* Allow buttons to wrap on smaller screens */
+  justify-content: center; /* Center buttons */
+  align-items: center;
+  gap: 1rem; /* Spacing between buttons */
+}
+
 .pressKitButton {
   display: inline-block;
   padding: 15px 30px;
@@ -44,7 +54,7 @@
   text-decoration: none;
   border: 2px solid #FFFF00; /* Accent color border */
   transition: background-color 0.2s ease, color 0.2s ease;
-  margin-top: 20px; /* Added some margin for spacing */
+  /* margin-top: 20px; /* Removed, as parent .pressKit now uses gap for spacing */
 }
 
 .pressKitButton:hover {

--- a/src/sections/PressKit/PressKit.jsx
+++ b/src/sections/PressKit/PressKit.jsx
@@ -14,31 +14,13 @@ const PressKit = () => {
 
   return (
     <section className={styles.pressKitSection}>
-      <h2 className={styles.sectionTitle}>Press Kit & Bio</h2>
+      <h2 className={styles.sectionTitle}>Our Story</h2> {/* Changed title */}
 
       <div className={styles.bioContainer}>
-        <h3>Our Story</h3>
+        {/* <h3>Our Story</h3> This sub-heading might be redundant if the main title is "Our Story" */}
         <p>{bio || 'Loading bio...'}</p>
       </div>
-
-      <div className={styles.downloadsContainer}>
-        <h3>Downloads</h3>
-        <ul>
-          <li>
-                <a href="/press-kit/photo1.jpg" download="AlarmAlarm_Photo1.jpg">Photo 1 (High Res)</a>
-          </li>
-          {/* Assuming there might be more photos, add placeholders or check public/press-kit */}
-          <li>
-                <a href="/public/press-kit/band_logo.png" download="AlarmAlarm_Logo.png">Band Logo (High Res)</a>
-          </li>
-          <li>
-                <a href="/press-kit.zip" download="AlarmAlarm_PressKit.zip">Full Press Kit (.zip)</a>
-          </li>
-        </ul>
-      </div>
-      <div className={styles.keywords}>
-        <p>Keywords for SEO: punk, punk rock, Malaga, Spanish punk band, Alarm! Alarm! music.</p>
-      </div>
+      {/* Downloads container and keywords div removed */}
     </section>
   );
 };

--- a/src/sections/Releases/Releases.jsx
+++ b/src/sections/Releases/Releases.jsx
@@ -1,0 +1,67 @@
+// src/sections/Releases/Releases.jsx
+import React from 'react';
+import styles from './Releases.module.css';
+
+// Placeholder data - replace with actual data and image paths
+const releasesData = [
+  {
+    id: 1,
+    title: 'Studio Album LP 1',
+    imageUrl: 'https://via.placeholder.com/180', // Using placeholder URL
+    spotifyUrl: 'https://open.spotify.com/album/placeholder1',
+  },
+  {
+    id: 2,
+    title: 'Studio Album LP 2',
+    imageUrl: 'https://via.placeholder.com/180', // Using placeholder URL
+    spotifyUrl: 'https://open.spotify.com/album/placeholder2',
+  },
+  {
+    id: 3,
+    title: 'Our Cool EP',
+    imageUrl: 'https://via.placeholder.com/180', // Using placeholder URL
+    spotifyUrl: 'https://open.spotify.com/album/placeholder3',
+  },
+  {
+    id: 4,
+    title: 'Live Insanity',
+    imageUrl: 'https://via.placeholder.com/180', // Using placeholder URL
+    spotifyUrl: 'https://open.spotify.com/album/placeholder4',
+  },
+  {
+    id: 5,
+    title: 'Compilation Chaos',
+    imageUrl: 'https://via.placeholder.com/180', // Using placeholder URL
+    spotifyUrl: 'https://open.spotify.com/album/placeholder5',
+  },
+];
+
+const Releases = () => {
+  return (
+    <section className={styles.releasesSection}>
+      <h2 className={styles.sectionTitle}>Releases</h2>
+      <div className={styles.releasesGrid}>
+        {releasesData.map((release) => (
+          <a
+            key={release.id}
+            href={release.spotifyUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.releaseLink}
+          >
+            <div className={styles.releaseItem}>
+              <img
+                src={release.imageUrl}
+                alt={release.title}
+                className={styles.albumArt}
+              />
+              <p className={styles.releaseName}>{release.title}</p>
+            </div>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Releases;

--- a/src/sections/Releases/Releases.module.css
+++ b/src/sections/Releases/Releases.module.css
@@ -1,0 +1,57 @@
+/* src/sections/Releases/Releases.module.css */
+.releasesSection {
+  padding: 2rem;
+  text-align: center;
+  background-color: #f0f0f0; /* Placeholder, adjust for theme */
+}
+
+.sectionTitle {
+  font-family: 'Courier New', Courier, monospace; /* Fanzine-like font */
+  font-size: 2.5rem;
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+  color: #333;
+  writing-mode: horizontal-tb;
+  transform: rotate(-2deg); /* Slight rotation for chaos */
+  display: inline-block; /* So transform applies correctly */
+}
+
+.releasesGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  margin-top: 1rem;
+}
+
+.releaseItem {
+  background-color: #fff;
+  border: 2px dashed #555; /* Dashed border for DIY feel */
+  padding: 1rem;
+  transform: rotate(1deg); /* Slight rotation */
+  transition: transform 0.2s ease-in-out;
+}
+
+.releaseItem:hover {
+    transform: rotate(-1deg) scale(1.05); /* Shift on hover */
+}
+
+.albumArt {
+  width: 100%;
+  max-width: 180px;
+  height: auto;
+  border: 1px solid #000;
+  margin-bottom: 0.5rem;
+  box-shadow: 3px 3px 0px rgba(0,0,0,0.2); /* Simple shadow */
+}
+
+.releaseName {
+  font-family: 'Times New Roman', Times, serif; /* Contrasting font */
+  font-size: 1.2rem;
+  color: #222;
+  margin-top: 0.5rem;
+}
+
+.releaseLink {
+  text-decoration: none;
+  color: inherit;
+}

--- a/src/sections/Tour/Tour.jsx
+++ b/src/sections/Tour/Tour.jsx
@@ -4,39 +4,41 @@ import styles from "./Tour.module.css";
 
 const Tour = () => {
   useEffect(() => {
-    const loadBandsintownWidget = () => {
-      if (
-        window.bandsintown &&
-        window.bandsintown.widgets &&
-        typeof window.bandsintown.widgets.load === "function"
-      ) {
-        console.log("Attempting to load Bandsintown widget...");
-        window.bandsintown.widgets.load();
+  const checkBandsintown = () => {
+    if (window.bandsintown) {
+      console.log("Bandsintown global object found:", window.bandsintown);
+      if (window.bandsintown.widgets && typeof window.bandsintown.widgets.load === 'function') {
+        console.log("Attempting to call Bandsintown widgets.load()...");
+        try {
+          window.bandsintown.widgets.load();
+          console.log("Bandsintown widgets.load() called.");
+        } catch (e) {
+          console.error("Error calling Bandsintown widgets.load():", e);
+        }
       } else {
-        console.error("Bandsintown widget script not found or not ready.");
+        console.log("Bandsintown widgets.load() function not found. The widget might load automatically via the <a> tag.");
       }
-    };
+    } else {
+      console.error("Bandsintown global object not found. Widget script from index.html might not have loaded or initialized correctly.");
+    }
+  };
 
-    // Try loading immediately
-    loadBandsintownWidget();
+  // Check immediately
+  checkBandsintown();
 
-    // And try again after a short delay in case of race conditions
-    const timer = setTimeout(() => {
-      console.log("Attempting to load Bandsintown widget (delayed)...");
-      loadBandsintownWidget();
-    }, 500); // 500ms delay
+  // And check again after a short delay
+  const timer = setTimeout(() => {
+    console.log("Checking for Bandsintown (delayed)...");
+    checkBandsintown();
+  }, 1000); // 1s delay, increased from 500ms
 
-    return () => clearTimeout(timer); // Cleanup timer on component unmount
-  }, []);
+  return () => clearTimeout(timer);
+}, []);
 
   return (
     <section className={styles.tourSection}>
       <h2 className={styles.sectionTitle}>Upcoming Shows</h2>
       <div className={styles.widgetContainer}>
-        <script
-          charset="utf-8"
-          src="https://widgetv3.bandsintown.com/main.min.js"
-        ></script>
         <a
           class="bit-widget-initializer"
           data-artist-name="id_15537054"


### PR DESCRIPTION
Feat(releases): Add new 'Releases' section with album placeholders. This section displays album art, titles, and Spotify links for the band's releases, styled with a DIY aesthetic.

Refactor(presskit): Streamline 'Press Kit' section to 'Our Story'. Removed download links and visible SEO keywords from the Press Kit section, focusing it solely on the band's biography.

Feat(contact): Add high-res media downloads to 'Contact' section. The 'Contact' section now includes buttons for downloading high-resolution band photos and logos. The section title was updated to 'Contact & Downloads'.

Chore(seo): Confirm SEO keywords in HTML meta tags. Ensured that SEO keywords are correctly placed in the index.html meta tags and removed the on-page display of keywords.