### PR TITLE
Migrate "Our Latest Noise" to Supabase

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -22,11 +22,24 @@ Execute the following SQL in the Supabase SQL Editor to enable RLS and allow pub
 -- Add alt_description column to brutalist_grid for SEO/GEO
 ALTER TABLE brutalist_grid ADD COLUMN IF NOT EXISTS alt_description TEXT;
 
+-- Create latest_noise table
+CREATE TABLE IF NOT EXISTS latest_noise (
+  id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  title TEXT NOT NULL,
+  message TEXT NOT NULL,
+  spotify_embed_url TEXT NOT NULL,
+  apple_music_url TEXT,
+  bandcamp_url TEXT,
+  youtube_music_url TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
 -- 2. Enable RLS for all tables
 ALTER TABLE brutalist_grid ENABLE ROW LEVEL SECURITY;
 ALTER TABLE albums ENABLE ROW LEVEL SECURITY;
 ALTER TABLE songs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE press_kit ENABLE ROW LEVEL SECURITY;
+ALTER TABLE latest_noise ENABLE ROW LEVEL SECURITY;
 
 -- Create policies to allow public read access (SELECT)
 -- Explicitly grant to both 'anon' and 'authenticated' roles.
@@ -34,6 +47,7 @@ CREATE POLICY "Allow public read access" ON brutalist_grid FOR SELECT TO anon, a
 CREATE POLICY "Allow public read access" ON albums FOR SELECT TO anon, authenticated USING (true);
 CREATE POLICY "Allow public read access" ON songs FOR SELECT TO anon, authenticated USING (true);
 CREATE POLICY "Allow public read access" ON press_kit FOR SELECT TO anon, authenticated USING (true);
+CREATE POLICY "Allow public read access" ON latest_noise FOR SELECT TO anon, authenticated USING (true);
 
 -- Storage Policies for public buckets
 CREATE POLICY "Allow public select on band_assets" ON storage.objects FOR SELECT TO anon, authenticated USING (bucket_id = 'band_assets');
@@ -43,7 +57,7 @@ CREATE POLICY "Allow public select on press_kit" ON storage.objects FOR SELECT T
 
 ## 3. Realtime Configuration
 
-To enable real-time updates for the "Brutalist Grid" (Social Feed) and the "Releases" section:
+To enable real-time updates for the "Brutalist Grid" (Social Feed), "Releases", and "Latest Noise" sections:
 1.  Go to the **Database** tab in your Supabase dashboard.
 2.  Select **Replication** from the sidebar.
 3.  Under `supabase_realtime`, click on **Source**.
@@ -51,6 +65,7 @@ To enable real-time updates for the "Brutalist Grid" (Social Feed) and the "Rele
     - `brutalist_grid`
     - `albums`
     - `songs`
+    - `latest_noise`
 
 The website will automatically update when new entries are added to these tables. Note that the "Brutalist Grid" is configured to show only the last 8 entries.
 

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -36,18 +36,28 @@ async function fetchData() {
       gridItems: [
         { id: 1, image_url: '', caption: 'Mock Photo', alt_description: 'Mock Alt' }
       ],
-      pressKit: []
+      pressKit: [],
+      latestNoise: {
+        title: 'Amateur Skater',
+        message: 'Stream our new EP, "Amateur Skater," right here via Spotify. For the best experience, use headphones and turn it up loud. Also available on all major streaming platforms.',
+        spotify_embed_url: 'https://open.spotify.com/embed/album/38AXd6UNJ3EDpUUZGx0ubE?utm_source=generator',
+        apple_music_url: 'https://music.apple.com/us/artist/alarm-alarm/1494187277',
+        bandcamp_url: 'https://alarmalarm.bandcamp.com/',
+        youtube_music_url: 'https://music.youtube.com/channel/UCmn_2X05dsJOHFXRM7fERsQ'
+      }
     };
   }
 
   const { data: albums } = await supabase.from('albums').select('*, songs(*)').order('release_date', { ascending: false });
   const { data: gridItems } = await supabase.from('brutalist_grid').select('*').order('created_at', { ascending: false }).limit(8);
   const { data: pressKit } = await supabase.from('press_kit').select('*');
+  const { data: latestNoise } = await supabase.from('latest_noise').select('*').order('created_at', { ascending: false }).limit(1).single();
 
   return {
     albums: albums || [],
     gridItems: gridItems || [],
-    pressKit: pressKit || []
+    pressKit: pressKit || [],
+    latestNoise: latestNoise || null
   };
 }
 
@@ -115,9 +125,26 @@ function generateHomeStaticHtml(data) {
     <p><a href="${asset.file_url}">${asset.label}</a></p>
   `).join('');
 
+  const noise = data.latestNoise;
+  const noiseHtml = noise ? `
+    <section id="music">
+      <h2>Our Latest Noise: "${noise.title}"</h2>
+      <p>${noise.message}</p>
+      <div>
+        <iframe src="${noise.spotify_embed_url}" width="100%" height="352" frameBorder="0" allowFullScreen allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+      </div>
+      <div>
+        ${noise.apple_music_url ? `<a href="${noise.apple_music_url}">Apple Music</a>` : ''}
+        ${noise.bandcamp_url ? `<a href="${noise.bandcamp_url}">Bandcamp</a>` : ''}
+        ${noise.youtube_music_url ? `<a href="${noise.youtube_music_url}">YouTube Music</a>` : ''}
+      </div>
+    </section>
+  ` : '';
+
   return `
     <header><h1>Alarm! Alarm! | Official Website</h1></header>
     <main>
+      ${noiseHtml}
       <section id="releases">
         <h2>Latest Releases</h2>
         ${releasesHtml}

--- a/src/sections/Music/Music.jsx
+++ b/src/sections/Music/Music.jsx
@@ -1,54 +1,104 @@
 // src/sections/Music/Music.jsx
 import styles from "./Music.module.css";
-import React from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import { supabase } from '../../supabaseClient';
 
-const SpotifyFallback = (
+const SpotifyFallback = ({ url }) => (
   <div className={styles.spotifyFallback}>
     <p>The Spotify player is currently unavailable.</p>
-    <a
-      href="https://open.spotify.com/album/38AXd6UNJ3EDpUUZGx0ubE"
-      target="_blank"
-      rel="noopener noreferrer"
-      className={styles.fallbackLink}
-    >
-      Listen on Spotify
-    </a>
+    {url && (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.fallbackLink}
+      >
+        Listen on Spotify
+      </a>
+    )}
   </div>
 );
 
 const Music = () => {
+  const initialData = window.__SITE_DATA__?.latestNoise || null;
+  const [noise, setNoise] = useState(initialData);
+
+  const fetchLatestNoise = useCallback(async () => {
+    if (!supabase) return;
+
+    const { data, error } = await supabase
+      .from('latest_noise')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .single();
+
+    if (error) {
+      console.error('Error fetching latest noise:', error);
+    } else {
+      setNoise(data);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLatestNoise();
+
+    if (!supabase) return;
+
+    const channel = supabase
+      .channel('latest_noise_realtime')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'latest_noise' },
+        () => fetchLatestNoise()
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [fetchLatestNoise]);
+
+  if (!noise) return null;
+
   return (
     <section id="music" className={styles.musicSection}>
-      <meta name="description" content="Stream the latest EPs from Alarm! Alarm!, the punk rock band from Málaga. Listen to 'Amateur Skater' and the classic '98-'99 EP." />
-      <h2 className={styles.sectionTitle}>Our Latest Noise: "Amateur Skater"</h2>
+      <meta name="description" content={`Stream the latest noise from Alarm! Alarm!: ${noise.title}. ${noise.message}`} />
+      <h2 className={styles.sectionTitle}>Our Latest Noise: "{noise.title}"</h2>
       <p className={styles.musicIntro}>
-        Stream our new EP, "Amateur Skater," right here via Spotify. For the best experience, use headphones and turn it up loud. Also available on all major streaming platforms.
+        {noise.message}
       </p>
-      <ErrorBoundary fallback={SpotifyFallback}>
+      <ErrorBoundary fallback={<SpotifyFallback url={noise.spotify_embed_url.replace('/embed', '')} />}>
         <div className={styles.spotifyEmbed}>
           <iframe
-            src="https://open.spotify.com/embed/album/38AXd6UNJ3EDpUUZGx0ubE?utm_source=generator"
+            src={noise.spotify_embed_url}
             width="100%"
             height="352"
             frameBorder="0"
             allowFullScreen
             allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
             loading="lazy"
-            title="Spotify Player for Amateur Skater EP"
+            title={`Spotify Player for ${noise.title}`}
           ></iframe>
         </div>
       </ErrorBoundary>
       <div className={styles.otherPlatforms}>
-        <a href="https://music.apple.com/us/artist/alarm-alarm/1494187277" target="_blank" rel="noopener noreferrer">
-          Apple Music
-        </a>
-        <a href="https://alarmalarm.bandcamp.com/" target="_blank" rel="noopener noreferrer">
-          Bandcamp
-        </a>
-        <a href="https://music.youtube.com/channel/UCmn_2X05dsJOHFXRM7fERsQ" target="_blank" rel="noopener noreferrer">
-          YouTube Music
-        </a>
+        {noise.apple_music_url && (
+          <a href={noise.apple_music_url} target="_blank" rel="noopener noreferrer">
+            Apple Music
+          </a>
+        )}
+        {noise.bandcamp_url && (
+          <a href={noise.bandcamp_url} target="_blank" rel="noopener noreferrer">
+            Bandcamp
+          </a>
+        )}
+        {noise.youtube_music_url && (
+          <a href={noise.youtube_music_url} target="_blank" rel="noopener noreferrer">
+            YouTube Music
+          </a>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
Migrated the "Our Latest Noise" section to be data-driven via Supabase. This includes:
1. Adding the SQL schema for the new `latest_noise` table to `SUPABASE_SETUP.md`.
2. Updating the prerendering script to include this data in the static build for SEO.
3. Updating the React frontend to fetch and display this data dynamically with Realtime support.

---
*PR created automatically by Jules for task [12280678256265886667](https://jules.google.com/task/12280678256265886667) started by @baronvonbirra*