### PR TITLE
Add Linktree Link to Contact Section and SEO Metadata

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -87,6 +87,7 @@ INSERT INTO site_strings (key, en, es, de, jp) VALUES
 ('booking_press', 'BOOKING/PRESS:', 'CONTRATACIÓN/PRENSA:', 'BOOKING/PRESSE:', 'ブッキング/プレス:'),
 ('official_channels', 'Official Channels (E-E-A-T)', 'Canales Oficiales (E-E-A-T)', 'Offizielle Kanäle (E-E-A-T)', '公式チャンネル (E-E-A-T)'),
 ('press_kit_title', 'Press Kit & Downloads', 'Press Kit y Descargas', 'Pressemappe & Downloads', 'プレス・キットとダウンロード'),
+('linktree_label', 'Linktree Official', 'Linktree Oficial', 'Offizielles Linktree', 'Linktree公式'),
 ('loading_downloads', 'Loading downloads...', 'Cargando descargas...', 'Downloads werden geladen...', 'ダウンロードを読み込み中...'),
 ('downloads_unavailable', 'Downloads currently unavailable.', 'Descargas no disponibles actualmente.', 'Downloads derzeit nicht verfügbar.', '現在ダウンロードできません。'),
 ('back_to_home', 'Back to Home', 'Volver al Inicio', 'Zurück zur Startseite', 'ホームに戻る')

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -64,6 +64,7 @@ async function fetchData() {
         contact_title: { en: 'Contact & Downloads' },
         booking_press: { en: 'BOOKING/PRESS:' },
         official_channels: { en: 'Official Channels (E-E-A-T)' },
+        linktree_label: { en: 'Linktree Official', es: 'Linktree Oficial', de: 'Offizielles Linktree', jp: 'Linktree公式' },
         press_kit_title: { en: 'Press Kit & Downloads' },
         back_to_home: { en: 'Back to Home' }
       }
@@ -133,7 +134,8 @@ function generateMusicGroupSchema() {
     "sameAs": [
       "https://open.spotify.com/artist/6Q3jUbGq2b2MeN2lMBYDxz",
       "https://alarmalarm.bandcamp.com/",
-      "https://www.instagram.com/alarmalarmmalaga"
+      "https://www.instagram.com/alarmalarmmalaga",
+      "https://linktr.ee/alarmalarm"
     ]
   };
 }
@@ -195,6 +197,7 @@ function generateHomeStaticHtml(data, lang) {
           <li><a href="https://open.spotify.com/artist/6Q3jUbGq2b2MeN2lMBYDxz" rel="me">Spotify Official</a></li>
           <li><a href="https://alarmalarm.bandcamp.com/" rel="me">Bandcamp Official</a></li>
           <li><a href="https://www.instagram.com/alarmalarmmalaga" rel="me">Instagram</a></li>
+          <li><a href="https://linktr.ee/alarmalarm" rel="me">${t(data.strings, 'linktree_label', lang) || 'Linktree'}</a></li>
         </ul>
         <div id="press-kit">
           <h3>${t(data.strings, 'press_kit_title', lang)}</h3>

--- a/src/sections/Contact/Contact.jsx
+++ b/src/sections/Contact/Contact.jsx
@@ -68,6 +68,14 @@ const Contact = () => {
           >
             Instagram
           </a>
+          <a
+            href="https://linktr.ee/alarmalarm"
+            target="_blank"
+            rel="me noopener noreferrer"
+            className={styles.officialLink}
+          >
+            {t('linktree_label') || 'Linktree'}
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
I have added the official Linktree link (https://linktr.ee/alarmalarm) to the website. This change includes:
1.  **UI Update:** A new "Linktree Official" button in the Contact section, supporting English, Spanish, German, and Japanese.
2.  **SEO & E-E-A-T:** The Linktree URL is now included in the `MusicGroup` JSON-LD schema's `sameAs` array and the prerendered static HTML, helping search engines verify the band's identity.
3.  **Documentation:** Updated `SUPABASE_SETUP.md` with the new translation key for future database initializations.
4.  **Verification:** Confirmed the change via linting, full production build, and visual screenshot verification.

---
*PR created automatically by Jules for task [9202234055488895615](https://jules.google.com/task/9202234055488895615) started by @baronvonbirra*