### PR TITLE
Fix GitHub Actions trigger and queuing errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy to GitHub Pages
 
-on:
+"on":
   push:
     branches:
       - main
@@ -41,14 +41,14 @@ jobs:
           if [ -z "$VITE_SUPABASE_URL" ]; then echo "VITE_SUPABASE_URL is NOT set"; else echo "VITE_SUPABASE_URL is set (length: ${#VITE_SUPABASE_URL})"; fi
           if [ -z "$VITE_SUPABASE_ANON_KEY" ]; then echo "VITE_SUPABASE_ANON_KEY is NOT set"; else echo "VITE_SUPABASE_ANON_KEY is set (length: ${#VITE_SUPABASE_ANON_KEY})"; fi
         env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || vars.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_SUPABASE_URL: "${{ secrets.VITE_SUPABASE_URL || vars.VITE_SUPABASE_URL }}"
+          VITE_SUPABASE_ANON_KEY: "${{ secrets.VITE_SUPABASE_ANON_KEY || vars.VITE_SUPABASE_ANON_KEY }}"
 
       - name: Build project
         run: npm run build
         env:
-          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL || vars.VITE_SUPABASE_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY || vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_SUPABASE_URL: "${{ secrets.VITE_SUPABASE_URL || vars.VITE_SUPABASE_URL }}"
+          VITE_SUPABASE_ANON_KEY: "${{ secrets.VITE_SUPABASE_ANON_KEY || vars.VITE_SUPABASE_ANON_KEY }}"
 
       - name: Verify Build Artifacts
         run: |


### PR DESCRIPTION
This PR fixes issues with the GitHub Actions deployment workflow failing to trigger on merges and throwing "Failed to queue workflow run" errors. 

The primary fixes include:
1. Quoting the `"on"` key in `deploy.yml` to prevent YAML 1.1 parsers from interpreting it as a boolean.
2. Wrapping GitHub Actions expressions in environment variables with double quotes to ensure they are always treated as strings by the YAML parser.

These changes ensure the workflow is correctly recognized and registered by GitHub's automation engine.

---
*PR created automatically by Jules for task [7597495674258027647](https://jules.google.com/task/7597495674258027647) started by @baronvonbirra*