### PR TITLE
Add social sharing image for link previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,14 +22,14 @@
     <meta property="og:url" content="https://alarmalarmmalaga.github.io/">
     <meta property="og:title" content="Alarm! Alarm! | Official Website">
     <meta property="og:description" content="Official website for Alarm! Alarm!, a punk rock band from Málaga.">
-    <meta property="og:image" content="https://alarmalarmmalaga.github.io/AlarmAlarm_icon.png">
+    <meta property="og:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://alarmalarmmalaga.github.io/">
     <meta property="twitter:title" content="Alarm! Alarm! | Official Website">
     <meta property="twitter:description" content="Official website for Alarm! Alarm!, a punk rock band from Málaga.">
-    <meta property="twitter:image" content="https://alarmalarmmalaga.github.io/AlarmAlarm_icon.png">
+    <meta property="twitter:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg">
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -391,6 +391,8 @@ async function prerender() {
     homeHtml = homeHtml.replace(/<meta property="twitter:url" content=".*?"\s*\/?>/g, `<meta property="twitter:url" content="${homeCanonical}" />`);
     homeHtml = homeHtml.replace(/<meta property="twitter:title" content=".*?"\s*\/?>/g, `<meta property="twitter:title" content="${homeTitle}" />`);
     homeHtml = homeHtml.replace(/<meta property="twitter:description" content=".*?"\s*\/?>/g, `<meta property="twitter:description" content="${homeDesc}" />`);
+    homeHtml = homeHtml.replace(/<meta property="og:image" content=".*?"\s*\/?>/g, `<meta property="og:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg" />`);
+    homeHtml = homeHtml.replace(/<meta property="twitter:image" content=".*?"\s*\/?>/g, `<meta property="twitter:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg" />`);
 
     // Inject SITE_DATA
     const siteDataScript = `<script>window.__SITE_DATA__ = ${JSON.stringify(data)};</script>`;
@@ -422,6 +424,8 @@ async function prerender() {
 
     epkHtml = epkHtml.replace(/<title>.*?<\/title>/, `<title>${epkTitle}</title>`);
     epkHtml = epkHtml.replace(/<meta name="description" content=".*?"\s*\/?>/g, `<meta name="description" content="${epkDesc}" />`);
+    epkHtml = epkHtml.replace(/<meta property="og:image" content=".*?"\s*\/?>/g, `<meta property="og:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg" />`);
+    epkHtml = epkHtml.replace(/<meta property="twitter:image" content=".*?"\s*\/?>/g, `<meta property="twitter:image" content="https://sacimvemsixvqghmhxtd.supabase.co/storage/v1/object/public/band_assets/header.jpg" />`);
 
     epkHtml = epkHtml.replace('</head>', `${siteDataScript}\n</head>`);
     epkHtml = epkHtml.replace('</head>', `${homeSchema}\n</head>`);


### PR DESCRIPTION
This change ensures that when the website link is shared on platforms like WhatsApp, Facebook, or Twitter, a high-quality photo (the band's header image) is displayed in the link preview. I updated the base `index.html` and the `scripts/prerender.js` build script to consistently inject the appropriate Open Graph and Twitter image meta tags across the site.

---
*PR created automatically by Jules for task [6979018258919646534](https://jules.google.com/task/6979018258919646534) started by @baronvonbirra*