### PR TITLE
Upgrade Node.js to v22 to fix build failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "temp-vite-project",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "type": "module",
   "homepage": "https://alarmalarmmalaga.github.io",
   "scripts": {


### PR DESCRIPTION
The build was failing during the prerendering stage with the error: "Node.js 20 detected without native WebSocket support." This occurred because the updated Supabase SDK requires native WebSockets, which were introduced in later Node.js versions (specifically, they are stable in Node 22).

I have:
1. Updated the GitHub Actions deployment workflow (`.github/workflows/deploy.yml`) to use Node.js 22.
2. Added the `engines` field to `package.json` to specify that Node.js >= 22.0.0 is required for this project.
3. Verified the fix by running the build and linting locally.

---
*PR created automatically by Jules for task [15593989576211251245](https://jules.google.com/task/15593989576211251245) started by @baronvonbirra*